### PR TITLE
Fix registry sync build

### DIFF
--- a/.github/workflows/docker-hub-deploy.yml
+++ b/.github/workflows/docker-hub-deploy.yml
@@ -14,4 +14,4 @@ jobs:
           REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           TARGET_REGISTRY_NAME: ${{ secrets.DOCKER_HUB_TARGET_REGISTRY_NAME }}
-          REPOSITORY_IMAGE_NAME: "docker-registry-sync"
+          TARGET_PROJECT_PATH_IN_GIT_REPO: "docker-registry-sync"

--- a/.github/workflows/docker-hub-deploy.yml
+++ b/.github/workflows/docker-hub-deploy.yml
@@ -1,7 +1,6 @@
 name: build + test + push images to Docker Hub
 on:
   push:
-  pull_request:
 
 jobs:
   docker-registry-sync:

--- a/.github/workflows/docker-hub-deploy.yml
+++ b/.github/workflows/docker-hub-deploy.yml
@@ -13,4 +13,5 @@ jobs:
         with:
           REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          TARGET_REGISTRY_NAME: ${{ secrets.DOCKER_HUB_TARGET_REGISTRY_NAME }}
           TARGET_PROJECT_PATH: "docker-registry-sync"

--- a/.github/workflows/docker-hub-deploy.yml
+++ b/.github/workflows/docker-hub-deploy.yml
@@ -14,4 +14,4 @@ jobs:
           REGISTRY_USER: ${{ secrets.DOCKER_HUB_USER }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           TARGET_REGISTRY_NAME: ${{ secrets.DOCKER_HUB_TARGET_REGISTRY_NAME }}
-          TARGET_PROJECT_PATH: "docker-registry-sync"
+          REPOSITORY_IMAGE_NAME: "docker-registry-sync"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 #
 .DEFAULT_GOAL := help
 SHELL         := /bin/bash
+# including .env file used for development
+include .env
+export $(shell sed 's/=.*//' .env)
 
 # Environments
 export VCS_URL          := $(shell git config --get remote.origin.url)
@@ -53,9 +56,7 @@ clean: ## Cleans all unversioned files in project
 
 .PHONY: debug-github-workflow
 debug-github-workflow: ## Runs the github worflow locally act is needed on the system
-	# get the dependency from https://github.com/nektos/act if you need to use it on your machine
 	@act -v \
-		-s DOCKER_HUB_USER=your_dockerhub_username \
-		-s DOCKER_HUB_TARGET_REGISTRY_NAME=your_dockerhub_username \
-		-s DOCKER_HUB_PASSWORD=your_dockerhub_password
-		
+		-s DOCKER_HUB_USER=${DOCKER_HUB_USER} \
+		-s DOCKER_HUB_TARGET_REGISTRY_NAME=${DOCKER_HUB_TARGET_REGISTRY_NAME} \
+		-s DOCKER_HUB_PASSWORD=${DOCKER_HUB_PASSWORD}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@
 SHELL         := /bin/bash
 # including .env file used for development
 include .env
-export $(shell sed 's/=.*//' .env)
 
 # Environments
 export VCS_URL          := $(shell git config --get remote.origin.url)

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,8 @@ clean: ## Cleans all unversioned files in project
 
 .PHONY: debug-github-workflow
 debug-github-workflow: ## Runs the github worflow locally act is needed on the system
-	@act -v -s DOCKER_HUB_USER=docke_hub_username -s DOCKER_HUB_PASSWORD=docke_hub_password
+	@act -v \
+		-s DOCKER_HUB_USER=dockerhub_username \
+		-s DOCKER_HUB_TARGET_REGISTRY_NAME=dockerhub_username \
+		-s DOCKER_HUB_PASSWORD=dockerhub_password
+		

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,9 @@ clean: ## Cleans all unversioned files in project
 
 .PHONY: debug-github-workflow
 debug-github-workflow: ## Runs the github worflow locally act is needed on the system
+	# get the dependency from https://github.com/nektos/act if you need to use it on your machine
 	@act -v \
-		-s DOCKER_HUB_USER=dockerhub_username \
-		-s DOCKER_HUB_TARGET_REGISTRY_NAME=dockerhub_username \
-		-s DOCKER_HUB_PASSWORD=dockerhub_password
+		-s DOCKER_HUB_USER=your_dockerhub_username \
+		-s DOCKER_HUB_TARGET_REGISTRY_NAME=your_dockerhub_username \
+		-s DOCKER_HUB_PASSWORD=your_dockerhub_password
 		

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To enable github workflow the following Git Hub secrets must be defined:
 
 - `DOCKER_HUB_USER` Docker Hub username
 - `DOCKER_HUB_PASSWORD` Docker Hub token (password usage is not advised)
+- `DOCKER_HUB_TARGET_REGISTRY_NAME` if using an organization might be different then the login credentials
 
 Projects under workflow:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Projects under workflow:
 
 - `docker-registry-sync`
 
+To test locally please you would need to install [act](https://github.com/nektos/act) and use the same secret names as environment 
+variables following in a .env file:
+
+- DOCKER_HUB_USER
+- DOCKER_HUB_PASSWORD
+- DOCKER_HUB_TARGET_REGISTRY_NAME
+
 ## Travis workflow
 
 

--- a/ci/github/action-build-and-push/Dockerfile
+++ b/ci/github/action-build-and-push/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update && apt-get install -y \
 RUN curl -L "https://github.com/docker/compose/releases/download/1.26.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-ADD entrypoint.bash /entrypoint.bash
 ADD print_as_header.py /code/print_as_header.py
+
+ADD entrypoint.bash /entrypoint.bash
 RUN chmod +x /entrypoint.bash
+
 ENTRYPOINT ["/entrypoint.bash"]

--- a/ci/github/action-build-and-push/README.md
+++ b/ci/github/action-build-and-push/README.md
@@ -10,9 +10,9 @@ To configure the action the following inputs are required:
 - `REGISTRY_USER`[**mandatory**] registry username
 - `REGISTRY_PASSWORD`[**mandatory**] registry password or access token
 - `TARGET_REGISTRY_NAME`[**mandatory**] identifies the final namespace where to push the image (might be different from the login name)
-- `TARGET_PROJECT_PATH`[**mandatory**] registry password or access token
+- `REPOSITORY_IMAGE_NAME`[**mandatory**] name of the image
 
-Inside the `TARGET_PROJECT_PATH` the action expects to find a Makefile as the following commands will be issued:
+Inside the `REPOSITORY_IMAGE_NAME` the action expects to find a Makefile as the following commands will be issued:
 
 - `make github-ci-pull` will attempt to pull a previous image (used as caching stage), this command may fail and the action will continue
 - `make github-ci-build` builds the image

--- a/ci/github/action-build-and-push/README.md
+++ b/ci/github/action-build-and-push/README.md
@@ -9,6 +9,7 @@ To configure the action the following inputs are required:
 - `REGISTRY_URL`[optional] url of the Docker registry defaults to Docker Hub
 - `REGISTRY_USER`[**mandatory**] registry username
 - `REGISTRY_PASSWORD`[**mandatory**] registry password or access token
+- `TARGET_REGISTRY_NAME`[**mandatory**] identifies the final namespace where to push the image (might be different from the login name)
 - `TARGET_PROJECT_PATH`[**mandatory**] registry password or access token
 
 Inside the `TARGET_PROJECT_PATH` the action expects to find a Makefile as the following commands will be issued:

--- a/ci/github/action-build-and-push/README.md
+++ b/ci/github/action-build-and-push/README.md
@@ -10,9 +10,9 @@ To configure the action the following inputs are required:
 - `REGISTRY_USER`[**mandatory**] registry username
 - `REGISTRY_PASSWORD`[**mandatory**] registry password or access token
 - `TARGET_REGISTRY_NAME`[**mandatory**] identifies the final namespace where to push the image (might be different from the login name)
-- `REPOSITORY_IMAGE_NAME`[**mandatory**] name of the image
+- `TARGET_PROJECT_PATH_IN_GIT_REPO`[**mandatory**] name of the folder and project name to be uploaded to Docker Hub
 
-Inside the `REPOSITORY_IMAGE_NAME` the action expects to find a Makefile as the following commands will be issued:
+Inside the folder pointed by `TARGET_PROJECT_PATH_IN_GIT_REPO` the action expects to find a Makefile as the following commands will be issued:
 
 - `make github-ci-pull` will attempt to pull a previous image (used as caching stage), this command may fail and the action will continue
 - `make github-ci-build` builds the image

--- a/ci/github/action-build-and-push/action.yml
+++ b/ci/github/action-build-and-push/action.yml
@@ -13,8 +13,8 @@ inputs:
   REGISTRY_PASSWORD:
     description: "registry password or access token"
     required: true
-  TARGET_PROJECT_PATH:
-    description: "registry password or access token"
+  REPOSITORY_IMAGE_NAME:
+    description: "name of the image"
     required: true
 
 runs:

--- a/ci/github/action-build-and-push/action.yml
+++ b/ci/github/action-build-and-push/action.yml
@@ -13,6 +13,9 @@ inputs:
   REGISTRY_PASSWORD:
     description: "registry password or access token"
     required: true
+  TARGET_REGISTRY_NAME:
+    description: "identifies the final namespace where to push the image (might be different from the login name)"
+    required: true
   TARGET_PROJECT_PATH_IN_GIT_REPO:
     description: "name of the folder and project name to be uploaded to Docker Hub"
     required: true

--- a/ci/github/action-build-and-push/action.yml
+++ b/ci/github/action-build-and-push/action.yml
@@ -13,8 +13,8 @@ inputs:
   REGISTRY_PASSWORD:
     description: "registry password or access token"
     required: true
-  REPOSITORY_IMAGE_NAME:
-    description: "name of the image"
+  TARGET_PROJECT_PATH_IN_GIT_REPO:
+    description: "name of the folder and project name to be uploaded to Docker Hub"
     required: true
 
 runs:

--- a/ci/github/action-build-and-push/entrypoint.bash
+++ b/ci/github/action-build-and-push/entrypoint.bash
@@ -14,8 +14,8 @@ docker-compose --version
 python3 /code/print_as_header.py "Logging into registry"
 docker login -u "$INPUT_REGISTRY_USER" -p "$INPUT_REGISTRY_PASSWORD" $INPUT_REGISTRY_URL
 
-python3 /code/print_as_header.py "Switching to project directory '$INPUT_REPOSITORY_IMAGE_NAME'"
-cd $INPUT_REPOSITORY_IMAGE_NAME
+python3 /code/print_as_header.py "Switching to project directory '$INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO'"
+cd $INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO
 
 python3 /code/print_as_header.py "Trying to pull existing image to enable caching"
 DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-pull  || true

--- a/ci/github/action-build-and-push/entrypoint.bash
+++ b/ci/github/action-build-and-push/entrypoint.bash
@@ -12,7 +12,7 @@ docker --version
 docker-compose --version
 
 python3 /code/print_as_header.py "Logging into registry"
-echo "--$INPUT_REGISTRY_URL--$INPUT_REGISTRY_USER--"
+
 echo "$INPUT_REGISTRY_PASSWORD" | docker login "$INPUT_REGISTRY_URL" --username "$INPUT_REGISTRY_USER" --password-stdin
 
 python3 /code/print_as_header.py "Switching to project directory '$INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO'"

--- a/ci/github/action-build-and-push/entrypoint.bash
+++ b/ci/github/action-build-and-push/entrypoint.bash
@@ -12,6 +12,7 @@ docker --version
 docker-compose --version
 
 python3 /code/print_as_header.py "Logging into registry"
+echo "--$INPUT_REGISTRY_URL--$INPUT_REGISTRY_USER--"
 echo "$INPUT_REGISTRY_PASSWORD" | docker login "$INPUT_REGISTRY_URL" --username "$INPUT_REGISTRY_USER" --password-stdin
 
 python3 /code/print_as_header.py "Switching to project directory '$INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO'"

--- a/ci/github/action-build-and-push/entrypoint.bash
+++ b/ci/github/action-build-and-push/entrypoint.bash
@@ -14,8 +14,8 @@ docker-compose --version
 python3 /code/print_as_header.py "Logging into registry"
 docker login -u "$INPUT_REGISTRY_USER" -p "$INPUT_REGISTRY_PASSWORD" $INPUT_REGISTRY_URL
 
-python3 /code/print_as_header.py "Switching to project directory '$INPUT_TARGET_PROJECT_PATH'"
-cd $INPUT_TARGET_PROJECT_PATH
+python3 /code/print_as_header.py "Switching to project directory '$INPUT_REPOSITORY_IMAGE_NAME'"
+cd $INPUT_REPOSITORY_IMAGE_NAME
 
 python3 /code/print_as_header.py "Trying to pull existing image to enable caching"
 DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-pull  || true

--- a/ci/github/action-build-and-push/entrypoint.bash
+++ b/ci/github/action-build-and-push/entrypoint.bash
@@ -18,15 +18,15 @@ python3 /code/print_as_header.py "Switching to project directory '$INPUT_TARGET_
 cd $INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO
 
 python3 /code/print_as_header.py "Trying to pull existing image to enable caching"
-DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-pull  || true
+DOCKER_REGISTRY=$INPUT_TARGET_REGISTRY_NAME make github-ci-pull  || true
 
 python3 /code/print_as_header.py "Building image"
-DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-build
+DOCKER_REGISTRY=$INPUT_TARGET_REGISTRY_NAME make github-ci-build
 
 python3 /code/print_as_header.py "Running tests"
-DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-tests
+DOCKER_REGISTRY=$INPUT_TARGET_REGISTRY_NAME make github-ci-tests
 
 python3 /code/print_as_header.py "Pushing image"
-DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-push
+DOCKER_REGISTRY=$INPUT_TARGET_REGISTRY_NAME make github-ci-push
 
 python3 /code/print_as_header.py "Completed without errors"

--- a/ci/github/action-build-and-push/entrypoint.bash
+++ b/ci/github/action-build-and-push/entrypoint.bash
@@ -18,15 +18,15 @@ python3 /code/print_as_header.py "Switching to project directory '$INPUT_TARGET_
 cd $INPUT_TARGET_PROJECT_PATH
 
 python3 /code/print_as_header.py "Trying to pull existing image to enable caching"
-DOCKER_REGISTRY=$INPUT_REGISTRY_USER make github-ci-pull  || true
+DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-pull  || true
 
 python3 /code/print_as_header.py "Building image"
-DOCKER_REGISTRY=$INPUT_REGISTRY_USER make github-ci-build
+DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-build
 
 python3 /code/print_as_header.py "Running tests"
-DOCKER_REGISTRY=$INPUT_REGISTRY_USER make github-ci-tests
+DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-tests
 
 python3 /code/print_as_header.py "Pushing image"
-DOCKER_REGISTRY=$INPUT_REGISTRY_USER make github-ci-push
+DOCKER_REGISTRY=$TARGET_REGISTRY_NAME make github-ci-push
 
 python3 /code/print_as_header.py "Completed without errors"

--- a/ci/github/action-build-and-push/entrypoint.bash
+++ b/ci/github/action-build-and-push/entrypoint.bash
@@ -12,7 +12,7 @@ docker --version
 docker-compose --version
 
 python3 /code/print_as_header.py "Logging into registry"
-docker login "$INPUT_REGISTRY_URL" -u "$INPUT_REGISTRY_USER" -p "$INPUT_REGISTRY_PASSWORD"
+echo "$INPUT_REGISTRY_PASSWORD" | docker login "$INPUT_REGISTRY_URL" -u "$INPUT_REGISTRY_USER" --password-stdin
 
 python3 /code/print_as_header.py "Switching to project directory '$INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO'"
 cd $INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO

--- a/ci/github/action-build-and-push/entrypoint.bash
+++ b/ci/github/action-build-and-push/entrypoint.bash
@@ -12,7 +12,7 @@ docker --version
 docker-compose --version
 
 python3 /code/print_as_header.py "Logging into registry"
-echo "$INPUT_REGISTRY_PASSWORD" | docker login "$INPUT_REGISTRY_URL" -u "$INPUT_REGISTRY_USER" --password-stdin
+echo "$INPUT_REGISTRY_PASSWORD" | docker login "$INPUT_REGISTRY_URL" --username "$INPUT_REGISTRY_USER" --password-stdin
 
 python3 /code/print_as_header.py "Switching to project directory '$INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO'"
 cd $INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO

--- a/ci/github/action-build-and-push/entrypoint.bash
+++ b/ci/github/action-build-and-push/entrypoint.bash
@@ -12,7 +12,7 @@ docker --version
 docker-compose --version
 
 python3 /code/print_as_header.py "Logging into registry"
-docker login -u "$INPUT_REGISTRY_USER" -p "$INPUT_REGISTRY_PASSWORD" $INPUT_REGISTRY_URL
+docker login "$INPUT_REGISTRY_URL" -u "$INPUT_REGISTRY_USER" -p "$INPUT_REGISTRY_PASSWORD"
 
 python3 /code/print_as_header.py "Switching to project directory '$INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO'"
 cd $INPUT_TARGET_PROJECT_PATH_IN_GIT_REPO

--- a/docker-registry-sync/Makefile
+++ b/docker-registry-sync/Makefile
@@ -120,7 +120,7 @@ github-ci-tests:	## reserved for Git Hub CI to start testsuite
 
 .PHONY: github-ci-push
 github-ci-push:	## reserved for Git Hub CI to push image
-	#@make push
+	@make push
 ifeq (${DOCKER_REG_SYNC_VERSION}, ${DOCKER_REG_SYNC_TAS_AS_STABLEVERSION})
 	@docker push ${DOCKER_REGISTRY}/${IMAGE_NAME}:stable
 endif


### PR DESCRIPTION
Adds a missing feature: targeting of deployment registry on Docker Hub.
Fixes an issue where the currently tagged build for ` docker-registry-sync` was not pushed