### PR TITLE
added pennsieve-agent

### DIFF
--- a/pennsieve-agent/Dockerfile
+++ b/pennsieve-agent/Dockerfile
@@ -1,0 +1,38 @@
+# reference for building https://github.com/Pennsieve/agent
+ARG PYTHON_VERSION="3.8.10"
+ARG PENNSIEVE_VERSION="0.3.5"
+FROM python:${PYTHON_VERSION}-slim-buster as base
+
+LABEL maintainer=sanderegg
+
+# Sets utf-8 encoding for Python et al
+ENV LANG=C.UTF-8
+
+FROM base as build
+
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    curl \
+    pkgconf \
+    libssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN git clone https://github.com/Pennsieve/agent.git /build/agent
+
+WORKDIR /build/agent
+
+RUN git checkout ${PENNSIEVE_VERSION}
+
+RUN cargo build --release
+
+FROM base AS production
+COPY --from=build /build/agent/target/release/pennsieve .
+ENTRYPOINT [ "./pennsieve" ]
+CMD ["--help"]

--- a/pennsieve-agent/Makefile
+++ b/pennsieve-agent/Makefile
@@ -1,0 +1,38 @@
+.DEFAULT_GOAL   := help
+export PYTHON_VERSION :=3.8.10
+export PENNSIEVE_VERSION  :=0.3.5
+export DOCKER_REGISTRY ?=itisfoundation
+
+export VCS_URL         := $(shell git config --get remote.origin.url)
+export VCS_REF         := $(shell git rev-parse --short HEAD)
+export BUILD_DATE      := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+.PHONY: help
+help: ## displays targets
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "%-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.PHONY: build
+build: ## builds image
+	@docker buildx bake --file docker-compose.yml
+
+.PHONY: push
+push: ## pushes image to Dockerhub
+	@docker push $(DOCKER_REGISTRY)/pennsieve-agent:${PYTHON_VERSION}-${PENNSIEVE_VERSION}
+
+.PHONY: pull
+pull: ## pulls image from Dockerhub
+	@docker pull $(DOCKER_REGISTRY)/pennsieve-agent:${PYTHON_VERSION}-${PENNSIEVE_VERSION}
+
+.PHONY: run
+run: ## runs the image
+	@docker run $(DOCKER_REGISTRY)/pennsieve-agent:${PYTHON_VERSION}-${PENNSIEVE_VERSION}
+
+define show-meta
+	$(foreach iid,$(shell docker images */$(1):* -q | sort | uniq),\
+		docker image inspect $(iid) | jq '.[0] | .RepoTags, .ContainerConfig.Labels';)
+endef
+
+.PHONY: info
+info: ## gives some information about the docker image
+	@docker images */pennsieve-agent:*;\
+	$(call show-meta,pennsieve-agent)

--- a/pennsieve-agent/docker-compose.yml
+++ b/pennsieve-agent/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+services:
+  pennsieve:
+    image: ${DOCKER_REGISTRY}/pennsieve-agent:${PYTHON_VERSION}-${PENNSIEVE_VERSION}
+    build:
+      context: .
+      labels:
+        org.label-schema.schema-version: "1.0"
+        org.label-schema.build-date: "${BUILD_DATE}"
+        org.label-schema.vcs-url: "${VCS_URL}"
+        org.label-schema.vcs-ref: "${VCS_REF}"
+      args:
+        - PYTHON_VERSION=${PYTHON_VERSION}
+        - PENNSIEVE_VERSION=${PENNSIEVE_VERSION}


### PR DESCRIPTION
added pennsieve-agent compiled using the same GLIBC 2.28.10 as in debian-buster distros (the one currently used in osparc-simcore)