### PR TITLE
Upgrade RabbitMQ to `v4.1.6`

### DIFF
--- a/rabbitmq/Makefile
+++ b/rabbitmq/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL   := help
-export RABBIT_VERSION  := 4.1.2-management
+export RABBIT_VERSION  := 4.1.6-management
 export DOCKER_REGISTRY ?= itisfoundation
 DOCKER_TARGET_PLATFORMS ?= linux/amd64
 comma := ,


### PR DESCRIPTION
This PR upgrades the RabbitMQ version from `4.1.2-management` to `4.1.6-management`, updating the base version used in the Docker image configuration.

- Updates RabbitMQ management version from 4.1.2 to 4.1.6

Links:
 - https://github.com/rabbitmq/rabbitmq-server/releases
 - Changes: https://github.com/rabbitmq/rabbitmq-server/compare/v4.1.2...v4.1.6
