### PR TITLE
🐛 qooxdoo-kit: fix translation race in compiler (multi-app builds drop translations)

### DIFF
--- a/qooxdoo-kit/Dockerfile
+++ b/qooxdoo-kit/Dockerfile
@@ -2,7 +2,7 @@ FROM node:10.16.3-alpine
 
 LABEL maintainer="oetiker,pcrespov"
 
-ENV DEP_PACKAGES="su-exec git tini jq"
+ENV DEP_PACKAGES="su-exec git tini jq patch"
 ENV ARM_DEP_PACKAGES="make g++ python2 python make g++"
 
 RUN apk add --no-cache ${DEP_PACKAGES}
@@ -21,6 +21,17 @@ RUN su - node -c "npm install npm@latest"
 RUN if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then export NPM_OPTIONS="--build-from-source"; else export NPM_OPTIONS=""; fi
 
 RUN su - node -c "npm install ${NPM_OPTIONS}"
+
+# Apply local patches to the third-party packages installed above.
+# Each *.patch is applied (with -p1) from the root of the package it targets.
+# --forward keeps the build idempotent; a patch that no longer applies fails the
+# build so the carried fix gets re-verified against the upgraded dependency.
+COPY --chown=node:node patches/ /home/node/patches/
+RUN cd /home/node/node_modules/@qooxdoo/compiler && \
+    for patchfile in /home/node/patches/*.patch; do \
+      echo "Applying ${patchfile}" && \
+      patch -p1 --forward < "${patchfile}"; \
+    done
 
 COPY --chown=node:node entrypoint.sh .
 RUN chmod 755 entrypoint.sh

--- a/qooxdoo-kit/Dockerfile
+++ b/qooxdoo-kit/Dockerfile
@@ -27,9 +27,11 @@ RUN su - node -c "npm install ${NPM_OPTIONS}"
 # --forward keeps the build idempotent; a patch that no longer applies fails the
 # build so the carried fix gets re-verified against the upgraded dependency.
 COPY --chown=node:node patches/ /home/node/patches/
-RUN cd /home/node/node_modules/@qooxdoo/compiler && \
+RUN set -e; \
+    cd /home/node/node_modules/@qooxdoo/compiler; \
     for patchfile in /home/node/patches/*.patch; do \
-      echo "Applying ${patchfile}" && \
+      [ -e "${patchfile}" ] || continue; \
+      echo "Applying ${patchfile}"; \
       patch -p1 --forward < "${patchfile}"; \
     done
 

--- a/qooxdoo-kit/patches/qx-compiler-translation-race.patch
+++ b/qooxdoo-kit/patches/qx-compiler-translation-race.patch
@@ -1,0 +1,29 @@
+# Fix a race condition in @qooxdoo/compiler's Analyser.getTranslation().
+#
+# When several applications share a single library (as all osparc-simcore products
+# share the "osparc" library), the compiler builds them concurrently and they all
+# request the same cached Translation object via getTranslation(library, locale).
+# Only the first caller entered the `if (!translation)` branch and awaited the .po
+# file read; every other concurrent caller saw the entry already cached and returned
+# the Translation object *before* its entries had been read. As a result only one
+# (random) application ended up with the translation catalog and all the others
+# shipped an empty one - e.g. only one product showed the Spanish translations.
+#
+# Moving `await translation.checkRead()` out of the `if` makes every caller wait for
+# the (idempotent, promise-guarded) read to complete before using the object.
+#
+# Applies to @qooxdoo/compiler 1.0.0-beta.20200111-0015 and 1.0.0-beta.20200409-1513
+# (identical code). The image build fails loudly if the patch no longer applies,
+# which signals the compiler was upgraded and the fix must be re-verified.
+--- a/source/class/qx/tool/compiler/Analyser.js
++++ b/source/class/qx/tool/compiler/Analyser.js
+@@ -978,8 +978,8 @@
+       if (!translation) {
+         translation = t.__translations[id] = new qx.tool.compiler.app.Translation(library, locale);
+         translation.setWriteLineNumbers(this.isWritePoLineNumbers());
+-        await translation.checkRead();
+       }
++      await translation.checkRead();
+       return translation;
+     },
+ 


### PR DESCRIPTION
Patches a race condition in `@qooxdoo/compiler` that causes translation catalogs to be dropped when several applications that share a library are compiled together. The fix is carried as a vendored patch applied to the compiler at image-build time.

## Why

In osparc-simcore all 9 products (`osparc`, `s4l`, `s4llite`, `s4lacad`, …) share the
single `osparc` library and are compiled concurrently by `qx compile`. With the released
Spanish (`es`) translations, only **one random product** actually shipped the catalog; all
the others rendered English. On the deployed products `qx.$$translations.es` was empty
(`Object.keys(...).length === 0`) even though the bundle's `qx.$$packageData[0].translations.es`
was correct — the catalog was simply never written into those apps.

### Root cause

A race in `Analyser.getTranslation()`:

```js
getTranslation: async function(library, locale) {
  var id = locale + ":" + library.getNamespace();
  var translation = t.__translations[id];
  if (!translation) {
    translation = t.__translations[id] = new Translation(library, locale); // cached synchronously
    translation.setWriteLineNumbers(this.isWritePoLineNumbers());
    await translation.checkRead();   // only the FIRST caller awaits the .po read
  }
  return translation;                // concurrent callers return the still-empty object
}